### PR TITLE
Cleaning up systemd for mongod.service

### DIFF
--- a/systemdfiles/mongod.service
+++ b/systemdfiles/mongod.service
@@ -4,14 +4,13 @@ After=network.target
 
 [Service]
 Type=forking
+PermissionsStartOnly=true
+ExecStartPre=-/usr/bin/mkdir /var/run/mozdefdb
+ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdefdb/
 PIDFile=/var/run/mozdefdb/mozdefdb.pid
-ExecStart=/usr/bin/mongod --config /etc/mongod.conf
+ExecStart=/usr/bin/mongod  --storageEngine=mmapv1 --config /etc/mongod.conf
 ExecReload=/bin/kill -HUP $MAINPID
-<<<<<<< HEAD
 Restart=always
-=======
-#Restart=always
->>>>>>> 8d519538b9afa92609f5afa587256e02a25a554e
 User=mozdef
 Group=mozdef
 StandardOutput=syslog


### PR DESCRIPTION
somehow this file had a diff excerpt in it.
Cleaned it up and added exec function to create the /var/run/mozdefdb directory